### PR TITLE
Patch: id overflow fix 

### DIFF
--- a/src/api/track.js
+++ b/src/api/track.js
@@ -71,7 +71,7 @@ export function getTrackDetail(ids) {
 /**
  * 获取歌词
  * 说明 : 调用此接口 , 传入音乐 id 可获得对应音乐的歌词 ( 不需要登录 )
- * @param {number} id - 音乐 id
+ * @param {bigint} id - 音乐 id
  */
 export function getLyric(id) {
   const fetchLatest = () => {
@@ -115,7 +115,7 @@ export function topSong(type) {
  * - id - 歌曲 id
  * - like - 默认为 true 即喜欢 , 若传 false, 则取消喜欢
  * @param {Object} params
- * @param {number} params.id
+ * @param {bigint} params.id
  * @param {boolean=} [params.like]
  */
 export function likeATrack(params) {
@@ -134,7 +134,7 @@ export function likeATrack(params) {
  * - sourceid - 歌单或专辑 id
  * - time - 歌曲播放时间,单位为秒
  * @param {Object} params
- * @param {number} params.id
+ * @param {bigint} params.id
  * @param {number} params.sourceid
  * @param {number=} params.time
  */

--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -76,7 +76,9 @@ export default class {
     this._current = 0; // 当前播放歌曲在播放列表里的index
     this._shuffledList = []; // 被随机打乱的播放列表，随机播放模式下会使用此播放列表
     this._shuffledCurrent = 0; // 当前播放歌曲在随机列表里面的index
+    // eslint-disable-next-line no-undef
     this._playlistSource = { type: 'album', id: BigInt(123) }; // 当前播放列表的信息
+    // eslint-disable-next-line no-undef
     this._currentTrack = { id: BigInt(4294967296) }; // 处理大于 32 位的整数
     this._playNextList = []; // 当这个list不为空时，会优先播放这个list的歌
     this._isPersonalFM = false; // 是否是私人FM模式

--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -76,8 +76,8 @@ export default class {
     this._current = 0; // 当前播放歌曲在播放列表里的index
     this._shuffledList = []; // 被随机打乱的播放列表，随机播放模式下会使用此播放列表
     this._shuffledCurrent = 0; // 当前播放歌曲在随机列表里面的index
-    this._playlistSource = { type: 'album', id: 123 }; // 当前播放列表的信息
-    this._currentTrack = { id: 86827685 }; // 当前播放歌曲的详细信息
+    this._playlistSource = { type: 'album', id: BigInt(123) }; // 当前播放列表的信息
+    this._currentTrack = { id: BigInt(4294967296) }; // 处理大于 32 位的整数
     this._playNextList = []; // 当这个list不为空时，会优先播放这个list的歌
     this._isPersonalFM = false; // 是否是私人FM模式
     this._personalFMTrack = { id: 0 }; // 私人FM当前歌曲


### PR DESCRIPTION
[网易云的歌曲ID已经超过了int32最大值，这会导致溢出问题，因此转为了BigInt以修复该问题]

禁用了eslint对BIgInt的未定义警告以确保build运行